### PR TITLE
fix: integrate Radix UI Portal for dropdown positioning

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "@pastel-palette/tailwindcss": "workspace:*",
     "@radix-ui/react-dialog": "1.1.14",
     "@radix-ui/react-label": "2.1.7",
+    "@radix-ui/react-portal": "1.1.9",
     "@radix-ui/react-select": "2.2.5",
     "@radix-ui/react-slider": "1.3.5",
     "clsx": "^2.1.1",

--- a/docs/src/components/ui/Dropdown.tsx
+++ b/docs/src/components/ui/Dropdown.tsx
@@ -1,3 +1,4 @@
+import * as Portal from '@radix-ui/react-portal'
 import { ChevronDown } from 'lucide-react'
 import { useEffect,useRef, useState } from 'react'
 
@@ -18,6 +19,8 @@ interface DropdownProps {
 export function Dropdown({ options, value, onChange, placeholder, className = '' }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const [buttonPosition, setButtonPosition] = useState({ top: 0, left: 0, width: 0 })
 
   const selectedOption = options.find(option => option.value === value)
 
@@ -34,14 +37,27 @@ export function Dropdown({ options, value, onChange, placeholder, className = ''
     }
   }, [])
 
+  // Update button position when dropdown opens
+  useEffect(() => {
+    if (isOpen && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setButtonPosition({
+        top: rect.bottom + window.scrollY,
+        left: rect.left + window.scrollX,
+        width: rect.width
+      });
+    }
+  }, [isOpen]);
+
   const handleSelect = (optionValue: string) => {
     onChange(optionValue)
     setIsOpen(false)
   }
 
   return (
-    <div ref={dropdownRef} className={`relative ${className}`}>
+    <div className={`relative ${className}`}>
       <button
+        ref={buttonRef}
         type="button"
         onClick={() => setIsOpen(!isOpen)}
         className="relative w-full cursor-pointer rounded-md bg-background border border-border py-2 pl-3 pr-10 text-left shadow-sm focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent hover:border-border-secondary transition-colors"
@@ -50,15 +66,22 @@ export function Dropdown({ options, value, onChange, placeholder, className = ''
           {selectedOption ? selectedOption.label : placeholder}
         </span>
         <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-          <ChevronDown 
-            className={`h-4 w-4 text-text-secondary transition-transform ${isOpen ? 'rotate-180' : ''}`} 
-            aria-hidden="true" 
+          <ChevronDown
+            className={`h-4 w-4 text-text-secondary transition-transform ${isOpen ? 'rotate-180' : ''}`}
+            aria-hidden="true"
           />
         </span>
       </button>
 
       {isOpen && (
-        <div className="absolute z-50 mt-1 w-full rounded-md bg-background border border-border shadow-xl">
+        <Portal.Root ref={dropdownRef}
+          style={{
+            position: 'absolute',
+            top: `${buttonPosition.top}px`,
+            left: `${buttonPosition.left}px`,
+            width: `${buttonPosition.width}px`,
+          }}
+          className="mt-1 rounded-md bg-background border border-border shadow-xl">
           <div className="max-h-60 overflow-auto py-1">
             {options.map((option) => (
               <button
@@ -93,7 +116,7 @@ export function Dropdown({ options, value, onChange, placeholder, className = ''
               </button>
             ))}
           </div>
-        </div>
+        </Portal.Root>
       )}
     </div>
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@radix-ui/react-label':
         specifier: 2.1.7
         version: 2.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal':
+        specifier: 1.1.9
+        version: 1.1.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-select':
         specifier: 2.2.5
         version: 2.2.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
Add the Radix UI Portal dependency and implement it for improved dropdown positioning.

This change enhances the dropdown's rendering by ensuring it appears correctly relative to its button and has the correct layer.


Before 

https://github.com/user-attachments/assets/fabb2264-9e26-4ca3-9825-e1d7aa3b6c5d

After

https://github.com/user-attachments/assets/be614269-999a-4c93-b511-ed73725f44f1

